### PR TITLE
fix removeGadget

### DIFF
--- a/graphql/mutations.js
+++ b/graphql/mutations.js
@@ -54,7 +54,7 @@ const Mutation = new GraphQLObjectType({
         id: { type: GraphQLString }
       },
       resolve(parent, args) {
-        return Gadget.findOneAndDelete(args.id).exec()
+        return Gadget.findByIdAndDelete(args.id).exec()
           .then(gadget => gadget.remove())
           .then(deletedGadget => deletedGadget)
           .catch(err => console.log(err))


### PR DESCRIPTION
replaced Gadget.findOneAndDelete with Gadget.findByIdAndDelete. findOneAndDelete deletes the first record regardless of what arguents are passed.